### PR TITLE
fix(transactions): update in recurrence frequency - single_occurence …

### DIFF
--- a/migrations/20240513084629_at-transactions-recurrence-frequency-drop-not-null.sql
+++ b/migrations/20240513084629_at-transactions-recurrence-frequency-drop-not-null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE transactions ALTER COLUMN recurrence_frequency DROP NOT NULL;

--- a/migrations/20240513093333_at-transactions-recurrence-frequency-unique.sql
+++ b/migrations/20240513093333_at-transactions-recurrence-frequency-unique.sql
@@ -1,0 +1,14 @@
+ALTER TABLE transactions ALTER COLUMN recurrence_frequency TYPE TEXT;
+
+DROP TYPE recurrence_frequency;
+
+CREATE TYPE transaction_recurrency AS ENUM(
+    'SINGLE_OCCURRENCE'
+    'WEEKLY',
+    'MONTHLY',
+    'QUARTERLY',
+    'SEMI_ANUALLY',
+    'ANUALLY'
+);
+
+ALTER TABLE transactions ALTER COLUMN recurrence_frequency TYPE transaction_recurrency USING recurrence_frequency :: transaction_recurrency;

--- a/services/budget/src/domains/installments.rs
+++ b/services/budget/src/domains/installments.rs
@@ -40,6 +40,7 @@ impl CreateInstallment {
     pub fn next_due_date_by_frequency(&self, reference_date: NaiveDate) -> NaiveDate {
         // SAFE unwrap, reference date is always Some()
         match self.recurrence_frequency {
+            TransactionRecurrency::SingleOccurrence => reference_date,
             TransactionRecurrency::Monthly => {
                 reference_date.checked_add_months(Months::new(1)).unwrap()
             }

--- a/services/budget/src/handlers/installments.rs
+++ b/services/budget/src/handlers/installments.rs
@@ -23,9 +23,9 @@ impl Handler {
 
         for step in 1..=steps {
             let result = self
-            .installment_repository
-            .create_installment(&payload, step)
-            .await?;
+                .installment_repository
+                .create_installment(&payload, step)
+                .await?;
 
             reference_date = payload.next_due_date_by_frequency(reference_date);
             payload.due_date = reference_date;

--- a/services/budget/src/handlers/transactions.rs
+++ b/services/budget/src/handlers/transactions.rs
@@ -16,7 +16,7 @@ impl Handler {
             .create_transaction(transaction)
             .await?;
 
-        if let Some(step) = transaction.installment_number {
+        if transaction.generate_installment() {
             let installment_payload = CreateInstallment {
                 transaction_id: transaction.transaction_id.clone(),
                 amount: transaction.amount.clone(),
@@ -24,10 +24,12 @@ impl Handler {
                 month_reference: transaction.month_reference.clone(),
                 status: transaction.status.clone(),
                 year_reference: transaction.year_reference.clone(),
-                recurrence_frequency: transaction.recurrence_frequency.clone(),
+                recurrence_frequency: transaction.recurrence_frequency.clone().unwrap(),
             };
 
-            self.create_installment(installment_payload, step).await?;
+            // SAFE unwrap because the "generate_installment" validation
+            self.create_installment(installment_payload, transaction.installment_number.unwrap())
+                .await?;
         }
 
         Ok(transaction)

--- a/services/budget/src/repositories/transactions.rs
+++ b/services/budget/src/repositories/transactions.rs
@@ -108,7 +108,7 @@ impl TransactionRepository for SqlxRepository {
             transaction.category as TransactionCategory,
             transaction.account_id,
             transaction.recurring,
-            transaction.recurrence_frequency as TransactionRecurrency,
+            transaction.get_transaction_recurrence() as TransactionRecurrency,
             transaction.month_reference as MonthReference,
             transaction.year_reference,
             transaction.status as TransactionStatus,


### PR DESCRIPTION
implements new enum item "Single Occurrence" to the `recurrence_frequency` because there was a 'problem' when the repository try to intert a new transaction.

When the field is a enum type can't insert null value.